### PR TITLE
automatic filetype detection

### DIFF
--- a/ftdetect/ari.vim
+++ b/ftdetect/ari.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.ari set filetype=ari


### PR DESCRIPTION
Added `ftdetect/ari.vim` to automatically set the vim filetype to `ari` based on the extension.